### PR TITLE
feat(taskmanager): add algor to render statuses in own status type group

### DIFF
--- a/src/components/elements/taskmanager.tsx
+++ b/src/components/elements/taskmanager.tsx
@@ -14,6 +14,7 @@ interface Tag {
 }
 import { useRouter } from 'next/navigation';
 import { Badge } from '../ui/badge';
+import { ta } from 'date-fns/locale';
 
 interface taskProps {
   id: string;
@@ -385,6 +386,30 @@ export const TaskManager = ({ project_id }: TaskManageMentOverviewProp) => {
     });
     setShowTasks(sorted);
   };
+
+  const statusToInt = (status: string): number => {
+    const statusMap: { [key: string]: number } = {
+      Unassigned: 1,
+      Assigned: 2,
+      InRecheck: 3,
+      UnderReview: 4,
+      Done: 5,
+    };
+    return statusMap[status] || -1;
+  };
+
+  const groupingStatus = (task: taskProps, max: number): number => {
+    let currentMax = Math.min(max, statusToInt(task.status));
+
+    if (task.subtasks) {
+      currentMax = task.subtasks.reduce((acc, subtask) => {
+        return Math.min(acc, groupingStatus(subtask, currentMax));
+      }, currentMax);
+    }
+
+    return currentMax;
+  };
+
   return (
     <div className="h-auto w-[1580px] p-5 font-BaiJamjuree bg-white rounded-md border border-[#6b5c56] flex flex-col gap-6">
       <div className="text-black text-3xl font-semibold leading-9">{projectName}</div>
@@ -473,7 +498,7 @@ export const TaskManager = ({ project_id }: TaskManageMentOverviewProp) => {
             </div>
             <div className="w-full space-y-1">
               {showTasks
-                .filter((item) => item.status === status) // Match with the status property
+                .filter((item) => groupingStatus(item, 9) === statusToInt(status)) // Match with the status property
                 .map((item) => (
                   <SubtaskItem key={item.id} item={item} statusIcon={icon} />
                 ))}


### PR DESCRIPTION
# Pull Request Template

## Description

- #66
- add algorithms to grouping task by status in all task page

## Changes Made

*List out the specific changes or updates made in this PR.*

- [x] add algorithms to grouping task in all-task page

## How to Test

*Provide step-by-step instructions on how to verify the changes. Include any setup details or special conditions that need to be met.*

1. Check whether the task has the status or if its subtasks have the minimum status as shown.

## Screenshots (if applicable)

<img width="373" alt="ภาพถ่ายหน้าจอ 2567-12-21 เวลา 17 51 47" src="https://github.com/user-attachments/assets/c319a2e9-c496-4379-b945-0a5ab5facabe" />


## Checklist

*Please ensure that all boxes are checked (replace [ ] with [x]). This checklist will help in maintaining a high standard for each PR.*

- [x] I have tested the changes and they work as expected.
- [x] I have added relevant documentation (if applicable).
- [x] I have updated relevant tests (if applicable).
- [x] This PR has a descriptive title and description.
- [x] This PR follows the code style and conventions of the project.

