### PR TITLE
fix: add navigate project gantt page

### DIFF
--- a/src/components/elements/projectdetail.tsx
+++ b/src/components/elements/projectdetail.tsx
@@ -224,6 +224,11 @@ export const ProjectDetail = ({ project }: { project: Project }) => {
     Router.push(url);
   };
 
+  const gotoGantt = () => {
+    const url = `/dashboard/project/${project.id}`;
+    Router.push(url);
+  };
+
   return (
     <div className="w-full flex flex-col items-start justify-center gap-4 px-20">
       <div className="flex justify-between items-center w-full">
@@ -235,7 +240,13 @@ export const ProjectDetail = ({ project }: { project: Project }) => {
           <ProjectWorkspace project_id={project.id} />
           <div className="self-stretch h-[120px] flex-col justify-center items-end gap-3 flex">
             <hr className="my-4 w-full border-t-1 border-gray-200" />
-            <div className="justify-start items-start gap-1 inline-flex">
+            <div className="justify-start items-start gap-2 inline-flex">
+              <Button
+                className="text-black bg-neutral-200 "
+                variant={'destructive'}
+                onClick={gotoGantt}>
+                View gantt chart
+              </Button>
               <Button
                 variant="destructive"
                 className="px-4 py-2 bg-brown justify-center items-center gap-2.5 flex"


### PR DESCRIPTION
# Pull Request Template

## Description

เพิ่มปุ่ม "View gantt chart" ในหน้ารายละเอียดโปรเจกต์ เพื่อให้สามารถนำผู้ใช้ไปยังหน้า Gantt chart ของโปรเจกต์นั้น ๆ ได้โดยตรง

## Changes Made

* [x] เพิ่มฟังก์ชัน `gotoGantt()` เพื่อจัดการ routing ไปยัง `/dashboard/project/${project.id}`
* [x] เพิ่ม `<Button>` ที่เรียกใช้ `gotoGantt` บน UI

## How to Test

1. ไปที่หน้า project detail
2. ตรวจสอบว่ามีปุ่ม “View gantt chart” ปรากฏอยู่
3. คลิกปุ่มดังกล่าว
4. ตรวจสอบว่าเบราว์เซอร์นำทางไปยัง `/dashboard/project/[projectId]` อย่างถูกต้อง

## Checklist

* [x] I have tested the changes and they work as expected.
* [x] I have added relevant documentation (if applicable).
* [x] I have updated relevant tests (if applicable).
* [x] This PR has a descriptive title and description.
* [x] This PR follows the code style and conventions of the project.

## Additional Notes

> **ต้องเช็ค role ที่เห็นปุ่มไหม ?**