### PR TITLE
fix(money projectcard&projectdetail): add tooltip & fix order money 

### DIFF
--- a/src/components/elements/projectList/projectCard.tsx
+++ b/src/components/elements/projectList/projectCard.tsx
@@ -190,30 +190,7 @@ export const ProjectCard = ({
                           align="center"
                           className="z-50 overflow-visible ">
                           <p className="z-50 font-BaiJamjuree font-medium bg-white border border-gray-300 rounded-md px-2 py-1 text-sm">
-                            {project.budget.toLocaleString()}
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </div>
-                  </TooltipProvider>
-
-                  <TooltipProvider>
-                    <div className="flex flex-row items-center">
-                      <div className="flex items-center justify-center font-BaiJamjuree text-[24px] w-6 h-6 font-semibold -ml-1 text-blue">
-                        ฿
-                      </div>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="font-BaiJamjuree text-[14px] font-medium ml-2 truncate max-w-[250px] text-blue">
-                            {(project.budget-project.expense).toLocaleString()}
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent
-                          side="top"
-                          align="center"
-                          className="z-50 overflow-visible ">
-                          <p className="z-50 font-BaiJamjuree font-medium bg-white border border-gray-300 rounded-md px-2 py-1 text-sm text-blue">
-                            {(project.budget-project.expense).toLocaleString()}
+                            งบประมาณโครงการ : {project.budget.toLocaleString()}
                           </p>
                         </TooltipContent>
                       </Tooltip>
@@ -236,7 +213,30 @@ export const ProjectCard = ({
                           align="center"
                           className="z-50 overflow-visible ">
                           <p className="z-50 font-BaiJamjuree font-medium bg-white border border-gray-300 rounded-md px-2 py-1 text-sm text-[#EF4444] ">
-                            {project.expense.toLocaleString()}
+                            รายจ่าย : {project.expense.toLocaleString()}
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    </div>
+                  </TooltipProvider>
+
+                  <TooltipProvider>
+                    <div className="flex flex-row items-center">
+                      <div className="flex items-center justify-center font-BaiJamjuree text-[24px] w-6 h-6 font-semibold -ml-1 text-blue">
+                        ฿
+                      </div>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <div className="font-BaiJamjuree text-[14px] font-medium ml-2 truncate max-w-[250px] text-blue">
+                            {(project.budget-project.expense).toLocaleString()}
+                          </div>
+                        </TooltipTrigger>
+                        <TooltipContent
+                          side="top"
+                          align="center"
+                          className="z-50 overflow-visible ">
+                          <p className="z-50 font-BaiJamjuree font-medium bg-white border border-gray-300 rounded-md px-2 py-1 text-sm text-blue">
+                            งบประมาณคงเหลือ : {(project.budget-project.expense).toLocaleString()}
                           </p>
                         </TooltipContent>
                       </Tooltip>
@@ -259,7 +259,7 @@ export const ProjectCard = ({
                           align="center"
                           className="z-50 overflow-visible ">
                           <p className="z-50 font-BaiJamjuree font-medium bg-white border border-gray-300 rounded-md px-2 py-1 text-sm text-[#69BCA0]">
-                            {project.advance.toLocaleString()}
+                            เงินยืมรองจ่าย : {project.advance.toLocaleString()}
                           </p>
                         </TooltipContent>
                       </Tooltip>

--- a/src/components/elements/projectdetail.tsx
+++ b/src/components/elements/projectdetail.tsx
@@ -23,6 +23,12 @@ import type { Project } from '@/lib/shared';
 import { AssignedProjectOwner } from './assigned-projectowner';
 import { toast } from '@/hooks/use-toast';
 import { AssignedProjectMember } from './assigned-projectmember';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  TooltipProvider,
+} from '@radix-ui/react-tooltip';
 
 interface UsersProps {
   id: string;
@@ -139,6 +145,61 @@ const SumExpense = ({ expense }: { expense: number }) => {
   );
 };
 
+type ProjectFinanceItemProps = {
+  ariaLabel: string;
+  color: string; // Tailwind color class
+  label: string;
+  value: number;
+  tooltipLabel: string;
+  ValueComponent: React.ComponentType<{ value: number }>;
+};
+
+const ProjectFinanceItem: React.FC<ProjectFinanceItemProps> = ({
+  ariaLabel,
+  color,
+  label,
+  value,
+  tooltipLabel,
+  ValueComponent,
+}) => {
+  return (
+    <div
+      aria-label={ariaLabel}
+      className="h-10 justify-start items-center font-BaiJamjuree inline-flex"
+    >
+      {/* Label Zone */}
+      <div className="w-24 justify-start items-center gap-2 flex">
+        {/* Icon */}
+        <div className={`w-6 text-center text-[30px] font-semibold ${color}`}>
+          ฿
+        </div>
+        {/* Description */}
+        <p className={`text-xs font-medium leading-tight ${color}`}>
+          {label} :
+        </p>
+      </div>
+
+      {/* Tooltip */}
+      <Tooltip>
+        <TooltipTrigger>
+          <ValueComponent value={value} />
+        </TooltipTrigger>
+        <TooltipContent
+          side="top"
+          align="center"
+          className="z-50 overflow-visible"
+        >
+          <p
+            className={`z-50 font-BaiJamjuree font-medium bg-white border border-gray-300 rounded-md px-2 py-1 text-sm ${color}`}
+          >
+            {tooltipLabel} : {value.toLocaleString()}
+          </p>
+        </TooltipContent>
+      </Tooltip>
+    </div>
+  );
+}
+
 const MenuBar = ({ project }: { project: Project }) => {
   return (
     <div className="w-[360px] p-[20px] bg-white rounded-md border border-[#6b5c56] flex-col justify-center items-start gap-2 inline-flex">
@@ -168,59 +229,40 @@ const MenuBar = ({ project }: { project: Project }) => {
         {project && <ButtonAddTags project_id={project.id} />}
       </div>
 
-      <div aria-label="Budget" className="h-10 justify-start items-center inline-flex">
-        {/* Label Zone */}
-        <div className="w-24 justify-start items-center gap-2 flex">
-          {/* Icon */}
-          <div className="w-6 text-center text-black text-[30px] font-BaiJamjuree font-semibold">
-            ฿
-          </div>
-          {/* Describtion */}
-          <p className="text-black text-xs font-medium font-BaiJamjuree leading-tight">
-            งบประมาณโครงการ :{' '}
-          </p>
-        </div>
-        <SumBudget budget={project.budget} />
-      </div>
-
-      <div
-        aria-label="Remaining"
-        className="h-10 justify-start font-BaiJamjuree items-center inline-flex">
-        {/* Label Zone */}
-        <div className="w-24 justify-start items-center gap-2 flex">
-          {/* Icon */}
-          <div className="w-6 text-center text-blue text-[30px] font-semibold">฿</div>
-          {/* Describtion */}
-          <p className="text-blue text-xs font-medium  leading-tight">งบประมาณคงเหลือ : </p>
-        </div>
-        <SumRemaining remaining={project.budget - project.expense} />
-      </div>
-
-      <div
-        aria-label="Advance"
-        className="h-10 justify-start font-BaiJamjuree items-center inline-flex">
-        {/* Label Zone */}
-        <div className="w-24 justify-start items-center gap-2 flex">
-          {/* Icon */}
-          <div className="w-6 text-center text-green text-[30px] font-semibold">฿</div>
-          {/* Describtion */}
-          <p className="text-green text-xs font-medium  leading-tight">เงินยืมรองจ่าย : </p>
-        </div>
-        <SumAdvance advance={project.advance} />
-      </div>
-
-      <div
-        aria-label="Expense"
-        className="h-10 justify-start items-center font-BaiJamjuree inline-flex">
-        {/* Label Zone */}
-        <div className="w-24 justify-start items-center gap-2 flex">
-          {/* Icon */}
-          <div className="w-6 text-center text-red text-[30px] font-semibold">฿</div>
-          {/* Describtion */}
-          <p className="text-red text-xs font-medium  leading-tight">รายจ่าย : </p>
-        </div>
-        <SumExpense expense={project.expense} />
-      </div>
+      <TooltipProvider>
+        <ProjectFinanceItem
+          ariaLabel="Budget"
+          color="text-black"
+          label="งบประมาณโครงการ"
+          value={project.budget}
+          tooltipLabel="งบประมาณโครงการ"
+          ValueComponent={({ value }) => <SumBudget budget={value} />}
+        />
+        <ProjectFinanceItem
+          ariaLabel="Expense"
+          color="text-[#EF4444]"
+          label="รายจ่าย"
+          value={project.expense}
+          tooltipLabel="รายจ่าย"
+          ValueComponent={({ value }) => <SumExpense expense={value} />}
+        />
+        <ProjectFinanceItem
+          ariaLabel="Remaining"
+          color="text-blue"
+          label="งบประมาณคงเหลือ"
+          value={project.budget - project.expense}
+          tooltipLabel="งบประมาณคงเหลือ"
+          ValueComponent={({ value }) => <SumRemaining remaining={value} />}
+        />
+        <ProjectFinanceItem
+          ariaLabel="Advance"
+          color="text-[#69BCA0]"
+          label="เงินยืมรองจ่าย"
+          value={project.advance}
+          tooltipLabel="เงินยืมรองจ่าย"
+          ValueComponent={({ value }) => <SumAdvance advance={value} />}
+        />
+      </TooltipProvider>
 
       <div aria-label="date" className="h-10 justify-start items-center inline-flex">
         {/* Label Zone */}


### PR DESCRIPTION
# Pull Request Template

## Description

- Added money tooltips for the project card and project detail page.
- Changed display order to: งบประมาณ → รายจ่าย → คงเหลือ → รองจ่าย
(Black → Red → Blue → Green) for consistency.
- Created a new ProjectFinanceItem component to remove repetition and improve maintainability.

## Screenshots (if applicable)

Project Card
<img width="324" height="383" alt="ภาพถ่ายหน้าจอ 2568-08-10 เวลา 21 48 45" src="https://github.com/user-attachments/assets/e310e9bf-489e-47b5-8242-5b3347193223" />
On hover budget
<img width="397" height="404" alt="ภาพถ่ายหน้าจอ 2568-08-10 เวลา 21 49 30" src="https://github.com/user-attachments/assets/469ba1eb-9660-4f4b-87a8-46d14c717220" />
Project detail menubar
<img width="377" height="523" alt="ภาพถ่ายหน้าจอ 2568-08-10 เวลา 21 50 23" src="https://github.com/user-attachments/assets/089dcbf3-33fd-445e-9860-815125adfef7" />
On hover budget
<img width="384" height="515" alt="ภาพถ่ายหน้าจอ 2568-08-10 เวลา 21 50 47" src="https://github.com/user-attachments/assets/02dd7e1a-68dc-42c4-8eea-c563739c9498" />

## Additional Notes

ใน project detail page > menubar > component รายจ่าย ฝั่งซ้ายจะไม่ตรงกับชาวบ้าน คิดว่าน่าจะเพราะคำว่า "รายจ่าย" มันสั้น
<img width="378" height="417" alt="ภาพถ่ายหน้าจอ 2568-08-10 เวลา 21 52 41" src="https://github.com/user-attachments/assets/b393cef7-bc9c-41df-89f6-76bd77609491" />

---

