### PR TITLE
fix(permission): refactor permission

### DIFF
--- a/src/app/tasks/[task_id]/page.tsx
+++ b/src/app/tasks/[task_id]/page.tsx
@@ -144,30 +144,6 @@ export default async function TasksManageMentPage({
   // Task Owner สามารถจัดการ task ของตัวเองได้
   // Task Member สามารถจัดการ task ที่ตัวเองเป็น member ได้
   // Task Creator สามารถจัดการ task ที่ตัวเองสร้างได้
-  const canManageTags =
-    isSystemAdmin ||
-    roleInProject === 'ProjectOwner' ||
-    isTaskOwner ||
-    isTaskOwnerInArray ||
-    isTaskCreator;
-  const canManageMoney =
-    isSystemAdmin ||
-    roleInProject === 'ProjectOwner' ||
-    isTaskOwner ||
-    isTaskOwnerInArray ||
-    isTaskCreator;
-  const canManageDate =
-    isSystemAdmin ||
-    roleInProject === 'ProjectOwner' ||
-    isTaskOwner ||
-    isTaskOwnerInArray ||
-    isTaskCreator;
-  const canAssignTasks =
-    isSystemAdmin ||
-    roleInProject === 'ProjectOwner' ||
-    isTaskOwner ||
-    isTaskOwnerInArray ||
-    isTaskCreator;
 
   const workspace: Workspace = {
     id: task.id,
@@ -201,14 +177,8 @@ export default async function TasksManageMentPage({
 
         {/* Right Section */}
         <div className="flex flex-col gap-4 items-end">
-          <MenuBar
-            task={task}
-            canManageTags={canManageTags}
-            canManageMoney={canManageMoney}
-            canManageDate={canManageDate}
-            canAssignTasks={canAssignTasks}
-          />
-          {(isSystemAdmin || roleInProject === 'ProjectOwner') && <DeleteTask task={task} />}
+          <MenuBar task={task} />
+          <DeleteTask task={task} />
         </div>
       </div>
     </div>

--- a/src/app/tasks/_components/deleteTask.tsx
+++ b/src/app/tasks/_components/deleteTask.tsx
@@ -18,6 +18,7 @@ import BASE_URL from '@/lib/shared';
 import type { TaskProps } from '@/app/types/types';
 import { useEffect, useState } from 'react';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 export const DeleteTask = ({ task }: { task: TaskProps }) => {
   const router = useRouter();
@@ -35,27 +36,19 @@ export const DeleteTask = ({ task }: { task: TaskProps }) => {
     }
   };
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('deleteTask', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
+    checkPermission();
+  }, [task.projectId, task.id]);
 
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
   return (
     hasEditPermission && (
       <AlertDialog>

--- a/src/app/tasks/_components/menu-bar.tsx
+++ b/src/app/tasks/_components/menu-bar.tsx
@@ -11,19 +11,7 @@ import type { TaskManageMentProp } from '@/lib/shared';
 import { DatePickerWithRange } from '@/components/elements/date-feature';
 import type { TaskProps } from '@/app/types/types';
 
-const MenuBar = ({
-  task,
-  canManageTags,
-  canManageMoney,
-  canManageDate,
-  canAssignTasks,
-}: {
-  task: TaskProps;
-  canManageTags: boolean;
-  canManageMoney: boolean;
-  canManageDate: boolean;
-  canAssignTasks: boolean;
-}) => {
+const MenuBar = ({ task }: { task: TaskProps }) => {
   return (
     <div className="w-[360px] p-[20px] bg-white rounded-md border border-[#6b5c56] flex-col justify-center items-start gap-2 inline-flex">
       <div aria-label="status" className="h-10 justify-start items-center inline-flex">
@@ -61,7 +49,7 @@ const MenuBar = ({
             Member :{' '}
           </div>
         </div>
-        <AssignedTaskToMember task={task} canAssignTask={canAssignTasks} />
+        <AssignedTaskToMember task={task} />
       </div>
 
       <div aria-label="tag" className="h-fit justify-start items-start inline-flex">
@@ -72,7 +60,7 @@ const MenuBar = ({
           <p className="text-brown text-xs font-medium font-BaiJamjuree">Tag :</p>
         </div>
         {/* Description */}
-        <ButtonAddTags task={task} canManageTags={canManageTags} />
+        <ButtonAddTags task={task} />
       </div>
 
       <div aria-label="money" className="h-10 justify-start items-center inline-flex">
@@ -87,7 +75,7 @@ const MenuBar = ({
             Money :{' '}
           </div>
         </div>
-        <Money task={task} canManageMoney={canManageMoney} />
+        <Money task={task} />
       </div>
 
       <div aria-label="date" className="h-10 justify-start items-center inline-flex">
@@ -101,19 +89,7 @@ const MenuBar = ({
           </div>
         </div>
 
-        {canManageDate ? (
-          // ✅ Owner/Manager: ใช้ DatePicker ได้
-          <DatePickerWithRange task={task} />
-        ) : (
-          // 👀 Member: เห็นวันอย่างเดียว กดไม่ได้
-          <div className="h-8 px-2 text-sm bg-white rounded-md border justify-center items-center flex font-medium font-BaiJamjuree hover:cursor-pointer border-brown text-brown">
-            {task.startDate && task.endDate
-              ? `${new Date(task.startDate).toLocaleDateString()} - ${new Date(
-                  task.endDate,
-                ).toLocaleDateString()}`
-              : 'No date set'}
-          </div>
-        )}
+        <DatePickerWithRange task={task} />
       </div>
     </div>
   );

--- a/src/app/types/types.tsx
+++ b/src/app/types/types.tsx
@@ -50,3 +50,10 @@ export interface FilterTasks {
 export type ProjectRole = 'ProjectOwner' | 'Member' | undefined;
 
 export type TaskRole = 'assignee' | 'owner' | undefined;
+
+export type PermissionContext = {
+  projectRole: ProjectRole;
+  taskRole: TaskRole;
+  isAdmin: boolean;
+  isHead: boolean;
+};

--- a/src/components/elements/assigned-projectmember.tsx
+++ b/src/components/elements/assigned-projectmember.tsx
@@ -28,13 +28,9 @@ interface UsersInterfaces {
 
 interface AssignedProjectMemberProps {
   project: Project;
-  isMember?: boolean;
 }
 
-export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({
-  project,
-  isMember = false,
-}) => {
+export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({ project }) => {
   const [open, setOpen] = React.useState(false);
   const [selectedUser, setSelectedUser] = React.useState<UsersInterfaces[]>([]);
   const [usersList, setUsersList] = React.useState<UsersInterfaces[]>([]);
@@ -148,7 +144,7 @@ export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({
   }, [open, fetchUsers]);
 
   const handleSelectUser = async (userName: string) => {
-    if (!isMounted || !project || isMember) return; // เพิ่มการตรวจสอบ isMember
+    if (!isMounted || !project) return;
 
     const user = usersList.find((u) => u.name === userName);
     if (!user) return;
@@ -190,15 +186,11 @@ export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({
   };
 
   const handlePopoverOpenChange = (newOpen: boolean) => {
-    if (!isMember) {
-      setOpen(newOpen);
-    }
+    setOpen(newOpen);
   };
 
   const handleButtonClick = () => {
-    if (!isMember) {
-      setOpen(!open);
-    }
+    setOpen(!open);
   };
 
   return (
@@ -211,7 +203,7 @@ export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({
               <Button
                 variant="outline"
                 disabled={!hasEditPermission}
-                className={cn('h-8 px-2 hover:bg-gray-50', isMember && 'cursor-default')}
+                className={cn('h-8 px-2 hover:bg-gray-50')}
                 onClick={handleButtonClick}>
                 {selectedUser.length > 0 ? (
                   <div className="flex space-x-2 items-center">

--- a/src/components/elements/assigned-projectmember.tsx
+++ b/src/components/elements/assigned-projectmember.tsx
@@ -17,6 +17,8 @@ import { Profile } from './profile';
 import BASE_URL, { BASE_SOCKET, type Project } from '@/lib/shared';
 import { getCookie } from 'cookies-next';
 import { toast } from '@/hooks/use-toast';
+import { can } from '@/permissions/helper';
+import { getUserRoleOnProjectTask } from '@/service/userService';
 
 interface UsersInterfaces {
   id: string;
@@ -40,12 +42,24 @@ export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({
   const [isMounted, setIsMounted] = React.useState(false);
   // Keep owner ids locally so dropdown can exclude owners in real-time
   const [ownerIds, setOwnerIds] = React.useState<string[]>([]);
+  const [hasEditPermission, setHasEditPermission] = React.useState(false);
   const MAX_VISIBLE_MEMBERS = 3;
 
   React.useEffect(() => {
     setIsMounted(true);
     setAuth(getCookie('auth')?.toString() || '');
   }, []);
+
+  React.useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project.id,
+      });
+      setHasEditPermission(can('editProjectMember', { projectRole, taskRole, isAdmin, isHead }));
+    };
+
+    checkPermission();
+  }, [project]);
 
   const fetchUsers = React.useCallback(async () => {
     if (!auth) return;
@@ -196,6 +210,7 @@ export const AssignedProjectMember: React.FC<AssignedProjectMemberProps> = ({
             <PopoverTrigger asChild className="border-brown text-brown">
               <Button
                 variant="outline"
+                disabled={!hasEditPermission}
                 className={cn('h-8 px-2 hover:bg-gray-50', isMember && 'cursor-default')}
                 onClick={handleButtonClick}>
                 {selectedUser.length > 0 ? (

--- a/src/components/elements/assigned-projectowner.tsx
+++ b/src/components/elements/assigned-projectowner.tsx
@@ -18,6 +18,8 @@ import BASE_URL, { BASE_SOCKET, type Project } from '@/lib/shared';
 import { getCookie } from 'cookies-next';
 import { toast } from '@/hooks/use-toast';
 import { Skeleton } from '@/components/ui/skeleton';
+import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 interface UsersInterfaces {
   id: string;
@@ -39,6 +41,7 @@ export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
   const [usersList, setUsersList] = React.useState<UsersInterfaces[]>([]);
   const [auth, setAuth] = React.useState('');
   const [isMounted, setIsMounted] = React.useState(false);
+  const [hasEditPermission, setHasEditPermission] = React.useState(false);
 
   const MAX_VISIBLE_MEMBERS = 3;
 
@@ -60,6 +63,17 @@ export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
       console.error('Failed to fetch users:', error);
     }
   }, [auth]);
+
+  React.useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project.id,
+      });
+      setHasEditPermission(can('editProjectOwner', { projectRole, taskRole, isAdmin, isHead }));
+    };
+
+    checkPermission();
+  }, [project]);
 
   React.useEffect(() => {
     if (!isMounted || !auth) return;
@@ -194,6 +208,7 @@ export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
             <PopoverTrigger asChild>
               <Button
                 type="button"
+                disabled={!hasEditPermission}
                 variant="outline"
                 className={cn(
                   'border-brown text-brown h-8 px-2 hover:bg-gray-50',

--- a/src/components/elements/assigned-projectowner.tsx
+++ b/src/components/elements/assigned-projectowner.tsx
@@ -29,13 +29,9 @@ interface UsersInterfaces {
 
 interface AssignedProjectOwnerProps {
   project: Project;
-  isMember?: boolean;
 }
 
-export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
-  project,
-  isMember = false,
-}) => {
+export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({ project }) => {
   const [open, setOpen] = React.useState(false);
   const [selectedUser, setSelectedUser] = React.useState<UsersInterfaces[]>([]);
   const [usersList, setUsersList] = React.useState<UsersInterfaces[]>([]);
@@ -144,7 +140,7 @@ export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
   );
 
   const handleSelectUser = async (userName: string) => {
-    if (!isMounted || !project || isMember) return; // เพิ่มการตรวจสอบ isMember
+    if (!isMounted || !project) return; // เพิ่มการตรวจสอบ isMember
 
     const user = usersList.find((u) => u.name === userName);
     if (!user) return;
@@ -180,15 +176,11 @@ export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
   };
 
   const handlePopoverOpenChange = (newOpen: boolean) => {
-    if (!isMember) {
-      setOpen(newOpen);
-    }
+    setOpen(newOpen);
   };
 
   const handleButtonClick = () => {
-    if (!isMember) {
-      setOpen(!open);
-    }
+    setOpen(!open);
   };
 
   if (!isMounted) {
@@ -210,10 +202,7 @@ export const AssignedProjectOwner: React.FC<AssignedProjectOwnerProps> = ({
                 type="button"
                 disabled={!hasEditPermission}
                 variant="outline"
-                className={cn(
-                  'border-brown text-brown h-8 px-2 hover:bg-gray-50',
-                  isMember && 'cursor-default',
-                )}
+                className={cn('border-brown text-brown h-8 px-2 hover:bg-gray-50')}
                 onClick={handleButtonClick}>
                 {selectedUser.length > 0 ? (
                   <div className="flex items-center space-x-2">

--- a/src/components/elements/assigned-task.tsx
+++ b/src/components/elements/assigned-task.tsx
@@ -23,6 +23,7 @@ import { toast } from '@/hooks/use-toast';
 import { useToast } from '@/hooks/use-toast';
 import { useEffect, useState } from 'react';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 interface UsersInterfaces {
   id: string;
@@ -30,10 +31,7 @@ interface UsersInterfaces {
   email: string;
 }
 
-export function AssignedTaskToMember({
-  task,
-  canAssignTask,
-}: { task: TaskProps; canAssignTask: boolean }) {
+export function AssignedTaskToMember({ task }: { task: TaskProps }) {
   const cookie = getCookie('auth');
   const auth = cookie?.toString() ?? '';
   const [open, setOpen] = React.useState(false);
@@ -166,32 +164,24 @@ export function AssignedTaskToMember({
 
   const { toast } = useToast();
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editMember', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
+    checkPermission();
+  }, [task.projectId, task.id]);
 
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
   return (
     <TooltipProvider>
       <div className="flex flex-row gap-1 flex-wrap">
         <div className="flex items-center space-x-4">
-          {canAssignTask ? (
+          {hasEditPermission ? (
             // ✅ กรณีมีสิทธิ์ assign → ใช้ Popover + ปุ่มกดได้
             <Popover open={open} onOpenChange={setOpen}>
               <PopoverTrigger asChild className="border-brown text-brown">

--- a/src/components/elements/blocknote.tsx
+++ b/src/components/elements/blocknote.tsx
@@ -20,6 +20,7 @@ import { jwtDecode, type JwtPayload } from 'jwt-decode';
 import { toast } from '@/hooks/use-toast';
 import { getUserRoleOnProjectTask } from '@/service/userService';
 import type { TaskProps } from '@/app/types/types';
+import { can } from '@/permissions/helper';
 
 const cookie = getCookie('auth');
 const auth = cookie?.toString() ?? '';
@@ -136,31 +137,22 @@ function EditorWithName({ userName, task }: { userName: string; task: TaskProps 
     setDescription(HTML);
   };
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editDescription', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(!isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
 
   return (
     <BlockNoteView
-      editable={!hasEditPermission}
+      editable={hasEditPermission}
       editor={editor}
       theme={'light'}
       onChange={onChangeBlock}

--- a/src/components/elements/blocknoteproject.tsx
+++ b/src/components/elements/blocknoteproject.tsx
@@ -18,6 +18,8 @@ import BASE_URL, { BASE_YSWEET, type ProjectOverviewProps } from '@/lib/shared';
 import { getCookie } from 'cookies-next';
 import { jwtDecode, type JwtPayload } from 'jwt-decode';
 import { toast } from '@/hooks/use-toast';
+import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 const cookie = getCookie('auth');
 const auth = cookie?.toString() ?? '';
@@ -46,6 +48,7 @@ function Document({ project_id }: ProjectOverviewProps) {
   const [canEdit, setCanEdit] = useState<boolean>(false); // เปลี่ยนจาก true เป็น false
   const [originalDescription, setOriginalDescription] = useState<string>('');
   const [isLoading, setIsLoading] = useState<boolean>(true); // เพิ่ม loading state
+  const [hasEditPermission, setHasEditPermission] = useState(false);
 
   useEffect(() => {
     const fetchDescription = async () => {
@@ -85,6 +88,16 @@ function Document({ project_id }: ProjectOverviewProps) {
         setIsLoading(false);
       }
     };
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project_id,
+      });
+      setHasEditPermission(
+        can('editProjectDescription', { projectRole, taskRole, isAdmin, isHead }),
+      );
+    };
+
+    checkPermission();
     fetchDescription();
   }, [project_id]);
 
@@ -141,7 +154,7 @@ function Document({ project_id }: ProjectOverviewProps) {
   return (
     <BlockNoteView
       editor={editor}
-      editable={canEdit}
+      editable={canEdit && hasEditPermission}
       aria-disabled={!canEdit}
       theme={'light'}
       onChange={onChangeBlock}

--- a/src/components/elements/button-add-projecttag.tsx
+++ b/src/components/elements/button-add-projecttag.tsx
@@ -31,7 +31,6 @@ interface Tags {
 
 interface ButtonAddTagsProps {
   project_id: string;
-  isMember?: boolean;
 }
 
 interface Owner {
@@ -43,7 +42,7 @@ interface Owner {
   activated: boolean;
 }
 
-export function ButtonAddTags({ project_id, isMember = false }: ButtonAddTagsProps) {
+export function ButtonAddTags({ project_id }: ButtonAddTagsProps) {
   const cookie = getCookie('auth');
   const auth = cookie?.toString() ?? '';
   const userid = (jwtDecode(auth) as { id: string }).id;
@@ -259,7 +258,7 @@ export function ButtonAddTags({ project_id, isMember = false }: ButtonAddTagsPro
         {hasEditPermission && (
           <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild className="border-brown text-brown">
-              {!isMember && (
+              {hasEditPermission && (
                 <Button variant="outline" className="h-8 px-2">
                   <p className="p-ui text-sm">Add tag</p>
                 </Button>

--- a/src/components/elements/button-add-projecttag.tsx
+++ b/src/components/elements/button-add-projecttag.tsx
@@ -21,6 +21,8 @@ import { jwtDecode } from 'jwt-decode';
 import { useEffect } from 'react';
 import { set } from 'date-fns';
 import { ProjectOwner } from './project-owner';
+import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 interface Tags {
   id: string;
@@ -52,6 +54,7 @@ export function ButtonAddTags({ project_id, isMember = false }: ButtonAddTagsPro
   const [open, setOpen] = React.useState(false);
   const [statuses, setStatuses] = React.useState<Tags[]>([]);
   const [selectedTags, setSelectedTags] = React.useState<Tags[]>([]);
+  const [hasEditPermission, setHasEditPermission] = React.useState<boolean>(false);
 
   // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   const pareJsonValue = React.useCallback((values: any) => {
@@ -82,6 +85,17 @@ export function ButtonAddTags({ project_id, isMember = false }: ButtonAddTagsPro
 
     fetchOwner();
   }, [auth, userid]);
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project_id,
+      });
+      setHasEditPermission(can('editProjectTag', { projectRole, taskRole, isAdmin, isHead }));
+    };
+
+    checkPermission();
+  }, [project_id]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: <explanation>
   useEffect(() => {
@@ -242,46 +256,48 @@ export function ButtonAddTags({ project_id, isMember = false }: ButtonAddTagsPro
               })
           : undefined}
 
-        <Popover open={open} onOpenChange={setOpen}>
-          <PopoverTrigger asChild className="border-brown text-brown">
-            {!isMember && (
-              <Button variant="outline" className="h-8 px-2">
-                <p className="p-ui text-sm">Add tag</p>
-              </Button>
-            )}
-          </PopoverTrigger>
-          <PopoverContent className="p-0" side="right" align="start">
-            <Command>
-              <CommandInput placeholder="Add tag ..." />
-              <CommandList>
-                <CommandEmpty>No results found.</CommandEmpty>
-                <CommandGroup>
-                  {statuses.map((status) => {
-                    // Hide Accept/Rework from non-Head users
-                    if (['Approved'].includes(status.name) && !isHead && !isadmin) return null;
+        {hasEditPermission && (
+          <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild className="border-brown text-brown">
+              {!isMember && (
+                <Button variant="outline" className="h-8 px-2">
+                  <p className="p-ui text-sm">Add tag</p>
+                </Button>
+              )}
+            </PopoverTrigger>
+            <PopoverContent className="p-0" side="right" align="start">
+              <Command>
+                <CommandInput placeholder="Add tag ..." />
+                <CommandList>
+                  <CommandEmpty>No results found.</CommandEmpty>
+                  <CommandGroup>
+                    {statuses.map((status) => {
+                      // Hide Accept/Rework from non-Head users
+                      if (['Approved'].includes(status.name) && !isHead && !isadmin) return null;
 
-                    return (
-                      <CommandItem key={status.id} value={status.name} onSelect={handleSelectTag}>
-                        <Circle
-                          className={cn(
-                            'mr-2 h-4 w-4',
-                            status.name === 'Approved'
-                              ? 'fill-blue text-blue'
-                              : 'fill-greenLight text-greenLight',
-                            selectedTags.some((tag) => tag.id === status.id)
-                              ? 'opacity-100'
-                              : 'opacity-40',
-                          )}
-                        />
-                        <span>{status.name}</span>
-                      </CommandItem>
-                    );
-                  })}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+                      return (
+                        <CommandItem key={status.id} value={status.name} onSelect={handleSelectTag}>
+                          <Circle
+                            className={cn(
+                              'mr-2 h-4 w-4',
+                              status.name === 'Approved'
+                                ? 'fill-blue text-blue'
+                                : 'fill-greenLight text-greenLight',
+                              selectedTags.some((tag) => tag.id === status.id)
+                                ? 'opacity-100'
+                                : 'opacity-40',
+                            )}
+                          />
+                          <span>{status.name}</span>
+                        </CommandItem>
+                      );
+                    })}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+        )}
       </div>
     </>
   );

--- a/src/components/elements/button-add-tag.tsx
+++ b/src/components/elements/button-add-tag.tsx
@@ -20,12 +20,10 @@ import type { TaskProps, TagProps } from '@/app/types/types';
 import { useToast } from '@/hooks/use-toast';
 import { useEffect, useState } from 'react';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 // Mock data
-export function ButtonAddTags({
-  task,
-  canManageTags,
-}: { task: TaskProps; canManageTags: boolean }) {
+export function ButtonAddTags({ task }: { task: TaskProps }) {
   const cookie = getCookie('auth');
   const auth = cookie?.toString() ?? '';
   const [open, setOpen] = React.useState(false);
@@ -156,27 +154,19 @@ export function ButtonAddTags({
   };
   const { toast } = useToast();
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editTag', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
+    checkPermission();
+  }, [task.projectId, task.id]);
 
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
   return (
     <>
       <div className="flex flex-row max-w-[212px] flex-wrap items-center justify-start overflow-hidden gap-x-1.5">
@@ -189,7 +179,7 @@ export function ButtonAddTags({
                 <span className="text-sm font-BaiJamjuree font-medium text-ellipsis overflow-hidden max-w-[180px]">
                   {tag.name}
                 </span>
-                {canManageTags && (
+                {hasEditPermission && (
                   <button
                     type="button"
                     onClick={() => {
@@ -205,7 +195,7 @@ export function ButtonAddTags({
           : undefined}
 
         {/* ปุ่ม Add tag จะถูกซ่อนเมื่อ canManageTags === false */}
-        {canManageTags && (
+        {hasEditPermission && (
           <Popover open={open} onOpenChange={setOpen}>
             <PopoverTrigger asChild className=" border-brown text-brown ">
               <Button variant="outline" className="h-8 px-2">

--- a/src/components/elements/date-feature.tsx
+++ b/src/components/elements/date-feature.tsx
@@ -16,6 +16,7 @@ import { toast } from '@/hooks/use-toast';
 import { getUserRoleOnProjectTask } from '@/service/userService';
 import { useEffect, useState } from 'react';
 import type { TaskProps } from '@/app/types/types';
+import { can } from '@/permissions/helper';
 
 // FUNCTION USING INSTRUCTION
 //================================================================
@@ -269,27 +270,18 @@ function DatePickerWithRange({ task }: { task: TaskProps }) {
   };
 
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editDate', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
   return (
     <div className={cn('grid gap-2')}>
       <Popover>
@@ -475,10 +467,23 @@ function DatePickerWithRangeProject({
     }
   };
 
+  const [hasEditPermission, setHasEditPermission] = useState(false);
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project.id,
+      });
+      setHasEditPermission(can('editProjectDate', { projectRole, taskRole, isAdmin, isHead }));
+    };
+
+    checkPermission();
+  }, [project.id]);
+
   return (
     <div className={cn('grid gap-2')}>
       <Popover onOpenChange={handlePopoverOpenChange}>
-        <PopoverTrigger asChild className="border-brown h-8 px-2">
+        <PopoverTrigger asChild className="border-brown h-8 px-2" disabled={!hasEditPermission}>
           <Button
             id="date"
             variant={'outline'}

--- a/src/components/elements/date-feature.tsx
+++ b/src/components/elements/date-feature.tsx
@@ -319,10 +319,7 @@ function DatePickerWithRange({ task }: { task: TaskProps }) {
 }
 
 // Exporting for Project Page.
-function DatePickerWithRangeProject({
-  project,
-  isMember,
-}: { project: DateInterface; isMember?: boolean }) {
+function DatePickerWithRangeProject({ project }: { project: DateInterface }) {
   const [date, setDate] = React.useState<DateRange | undefined>({
     from: undefined,
     to: undefined,
@@ -414,7 +411,7 @@ function DatePickerWithRangeProject({
 
   // Handle calendar selection (เหมือน date feature)
   const handleCalendarSelect = async (range: DateRange | undefined) => {
-    if (!range?.from || isMember) return; // เพิ่มการตรวจสอบ isMember
+    if (!range?.from) return; // เพิ่มการตรวจสอบ isMember
 
     let patchedRange = range;
     // Logic: กดครั้งแรกให้ start/end เป็นวันเดียวกัน, กดครั้งที่สองถึงจะเป็น range
@@ -455,13 +452,13 @@ function DatePickerWithRangeProject({
   };
 
   const handlePopoverOpenChange = (newOpen: boolean) => {
-    if (!isMember) {
+    if (hasEditPermission) {
       // ใช้ default behavior ของ Popover
     }
   };
 
   const handleButtonClick = () => {
-    if (isMember) {
+    if (!hasEditPermission) {
       // ป้องกันการเปิด popover
       return false;
     }
@@ -489,7 +486,6 @@ function DatePickerWithRangeProject({
             variant={'outline'}
             className={cn(
               `font-BaiJamjuree text-sm text-brown hover:bg-gray-50 ${!date && 'text-muted-foreground'}`,
-              isMember && 'cursor-default',
             )}
             onClick={handleButtonClick}>
             {date?.from ? (
@@ -505,18 +501,16 @@ function DatePickerWithRangeProject({
             )}
           </Button>
         </PopoverTrigger>
-        {!isMember && (
-          <PopoverContent className="w-auto p-0 z-1 p-ui" align="start">
-            <Calendar
-              initialFocus
-              mode="range"
-              defaultMonth={date?.from}
-              selected={date}
-              onSelect={handleCalendarSelect}
-              numberOfMonths={2}
-            />
-          </PopoverContent>
-        )}
+        <PopoverContent className="w-auto p-0 z-1 p-ui" align="start">
+          <Calendar
+            initialFocus
+            mode="range"
+            defaultMonth={date?.from}
+            selected={date}
+            onSelect={handleCalendarSelect}
+            numberOfMonths={2}
+          />
+        </PopoverContent>
       </Popover>
     </div>
   );

--- a/src/components/elements/emoji.tsx
+++ b/src/components/elements/emoji.tsx
@@ -11,6 +11,7 @@ import { jwtDecode } from 'jwt-decode';
 import type { TaskProps } from '@/app/types/types';
 import { toast } from '@/hooks/use-toast';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 const Picker = dynamic(() => import('emoji-picker-react'), { ssr: true, loading: () => null });
 
@@ -113,27 +114,18 @@ const Emoji = ({ task }: { task: TaskProps }) => {
   const sortedEmojis = [...emojis].sort((a, b) => b.id.localeCompare(a.id));
 
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editEmoji', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
   return (
     <div className="flex texts-center items-center justify-center">
       {hasEditPermission ? (

--- a/src/components/elements/money.tsx
+++ b/src/components/elements/money.tsx
@@ -24,12 +24,13 @@ import { moneyAtom } from '@/atom';
 import type { TaskProps } from '@/app/types/types';
 import { useToast } from '@/hooks/use-toast';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 interface Budget {
   type: string;
   money: number;
 }
 
-const Money = ({ task, canManageMoney }: { task: TaskProps | null; canManageMoney: boolean }) => {
+const Money = ({ task }: { task: TaskProps | null }) => {
   enum TypeMoney {
     null = '',
     budget = 'budget',
@@ -283,36 +284,22 @@ const Money = ({ task, canManageMoney }: { task: TaskProps | null; canManageMone
   }
   const [hasEditPermission, setHasEditPermission] = useState(false);
 
-  const checkPermissions = useCallback(async () => {
-    if (!task) {
-      setHasEditPermission(false);
-      return;
-    }
-
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+  useEffect(() => {
+    if (!task) return;
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editMoney', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  }, [task]);
-  useEffect(() => {
-    checkPermissions();
-  }, [checkPermissions]);
+    checkPermission();
+  }, [task?.projectId, task?.id]);
 
   return (
     <Dialog open={openDialog} onOpenChange={setOpenDialog}>
-      {canManageMoney ? (
+      {hasEditPermission ? (
         // --- Owner/Manager: สามารถกดเปิด Dialog ได้ ---
         <DialogTrigger asChild>
           <div
@@ -328,7 +315,7 @@ const Money = ({ task, canManageMoney }: { task: TaskProps | null; canManageMone
         // --- Member: เห็นจำนวนเงินเฉพาะเมื่อมีงบแล้วเท่านั้น ---
         !(budgetList.type === TypeMoney.null || Number.isNaN(budgetList.money)) && (
           <div
-            className={`h-8 px-2 text-sm bg-white rounded-md border justify-center items-center flex font-medium font-BaiJamjuree border-brown text-brown ${getMoneyColor(
+            className={`h-8 px-2 text-sm bg-white rounded-md justify-center items-center flex font-medium font-BaiJamjuree text-brown ${getMoneyColor(
               budgetList.type,
             )}`}>
             {budgetList.money.toLocaleString()}

--- a/src/components/elements/project-owner.tsx
+++ b/src/components/elements/project-owner.tsx
@@ -9,6 +9,7 @@ import { toast } from '@/hooks/use-toast';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '../ui/tooltip';
 import { useEffect, useState } from 'react';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 export function ProjectOwner({ task }: { task: TaskProps }) {
   const [owner, setOwner] = React.useState<User[]>([]);
@@ -45,27 +46,18 @@ export function ProjectOwner({ task }: { task: TaskProps }) {
     fetchOwner();
   }, [task.projectId, auth]);
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editProjectOwner', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
   return (
     <TooltipProvider>
       <div className="flex flex-row gap-1 flex-wrap">

--- a/src/components/elements/project-workspace.tsx
+++ b/src/components/elements/project-workspace.tsx
@@ -10,6 +10,8 @@ import BASE_URL, {
 import { getCookie } from 'cookies-next';
 import Blocknoteproject from './blocknoteproject';
 import { toast } from '@/hooks/use-toast';
+import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 const Workspace = ({ project_id }: ProjectOverviewProps) => {
   const [Title, setTitle] = useState<string>('');
@@ -95,6 +97,19 @@ const Workspace = ({ project_id }: ProjectOverviewProps) => {
     }
   }, [textAreaRef, Title]);
 
+  const [hasEditPermission, setHasEditPermission] = useState(false);
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project_id,
+      });
+      setHasEditPermission(can('editProjectTitle', { projectRole, taskRole, isAdmin, isHead }));
+    };
+
+    checkPermission();
+  }, [project_id]);
+
   return (
     <div className="relative w-full">
       <label
@@ -105,7 +120,7 @@ const Workspace = ({ project_id }: ProjectOverviewProps) => {
       <textarea
         className="resize-none border-none w-full outline-none placeholder-gray-300 text-[30px] font-semibold font-Anuphan"
         placeholder="Task Title"
-        disabled={!canEdit}
+        disabled={!canEdit || !hasEditPermission}
         value={Title}
         onChange={(e) => {
           setTitle(e.target.value);

--- a/src/components/elements/projectdetail.tsx
+++ b/src/components/elements/projectdetail.tsx
@@ -221,7 +221,7 @@ const ProjectFinanceItem: React.FC<ProjectFinanceItemProps> = ({
   );
 };
 
-const MenuBar = ({ project, isMember }: { project: Project; isMember?: boolean }) => {
+const MenuBar = ({ project }: { project: Project }) => {
   return (
     <div className="w-[360px] p-[20px] bg-white rounded-md border border-[#6b5c56] flex-col justify-center items-start gap-2 inline-flex">
       <div aria-label="owner" className="h-10 justify-start items-center inline-flex">
@@ -229,14 +229,14 @@ const MenuBar = ({ project, isMember }: { project: Project; isMember?: boolean }
           <CrownIcon className="w-[24px] h-[24px] text-brown" />
           <p className="text-[#6b5c56] text-xs font-medium leading-tight">Owner : </p>
         </div>
-        {project && <AssignedProjectOwner project={project} isMember={isMember} />}
+        {project && <AssignedProjectOwner project={project} />}
       </div>
       <div aria-label="member" className="h-10 justify-start items-center inline-flex">
         <div className="w-24 justify-start items-center gap-2 flex">
           <Users className="w-[24px] h-[24px] text-brown" />
           <p className="text-brown text-xs font-medium font-BaiJamjuree">Member : </p>
         </div>
-        {project && <AssignedProjectMember project={project} isMember={isMember} />}
+        {project && <AssignedProjectMember project={project} />}
       </div>
 
       <div aria-label="tag" className="h-fit justify-start items-start inline-flex">
@@ -247,7 +247,7 @@ const MenuBar = ({ project, isMember }: { project: Project; isMember?: boolean }
           {/* Description */}
           <p className="text-brown text-xs font-medium font-BaiJamjuree">Tag : </p>
         </div>
-        {project && <ButtonAddTags project_id={project.id} isMember={isMember} />}
+        {project && <ButtonAddTags project_id={project.id} />}
       </div>
 
       <TooltipProvider>
@@ -293,7 +293,7 @@ const MenuBar = ({ project, isMember }: { project: Project; isMember?: boolean }
           {/* Describtion */}
           <p className="text-[#6b5c56] text-xs font-medium  leading-tight">Date : </p>
         </div>
-        {project && <DatePickerWithRangeProject project={project} isMember={isMember} />}
+        {project && <DatePickerWithRangeProject project={project} />}
       </div>
     </div>
   );
@@ -303,7 +303,6 @@ export const ProjectDetail = ({ project }: { project: Project }) => {
   const cookie = getCookie('auth');
   const auth = cookie?.toString() ?? '';
   const Router = useRouter();
-  const [isMember, setIsMember] = useState(false);
 
   // ตรวจสอบว่า auth token มีค่าและไม่ใช่ empty string
   useEffect(() => {
@@ -311,32 +310,7 @@ export const ProjectDetail = ({ project }: { project: Project }) => {
       console.error('No auth token found');
       return;
     }
-
-    try {
-      const userId = jwtDecode<{ id: string }>(auth);
-
-      const fetchUserRole = async () => {
-        try {
-          const response = await fetch(`${BASE_URL}/v2/users/userrole/${userId.id}`, {
-            headers: { Authorization: auth },
-            cache: 'no-store',
-          });
-          if (!response.ok) throw new Error(`Failed to fetch user role: ${response.status}`);
-
-          const data: { projects: ProjectData[]; isAdmin: boolean } = await response.json();
-          const Project = data.projects.find((p) => p.id === project.id);
-
-          setIsMember(Project?.role === 'Member');
-        } catch (error) {
-          console.error('Error fetching user role:', error);
-        }
-      };
-
-      fetchUserRole();
-    } catch (error) {
-      console.error('Error decoding JWT:', error);
-    }
-  }, [auth, project.id]);
+  }, [auth]);
 
   const handleClick = () => {
     const url = `/projects/${project.id}`;
@@ -376,8 +350,8 @@ export const ProjectDetail = ({ project }: { project: Project }) => {
           </div>
         </div>
         <div className="flex-col justify-between items-end gap-4 inline-flex">
-          <MenuBar project={project} isMember={isMember} />
-          <DeleteProject project_id={project.id} isMember={isMember} />
+          <MenuBar project={project} />
+          <DeleteProject project_id={project.id} />
         </div>
       </div>
     </div>

--- a/src/components/elements/projectdetail.tsx
+++ b/src/components/elements/projectdetail.tsx
@@ -27,6 +27,8 @@ import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from '@radix
 import { jwtDecode } from 'jwt-decode';
 import type { ProjectRole, TaskRole } from '@/app/types/types';
 import { useEffect, useState } from 'react';
+import { can } from '@/permissions/helper';
+import { getUserRoleOnProjectTask } from '@/service/userService';
 
 interface UsersProps {
   id: string;
@@ -50,7 +52,7 @@ interface DeleteTaskProps {
   isMember?: boolean;
 }
 
-const DeleteProject: React.FC<DeleteTaskProps> = ({ project_id, isMember = false }) => {
+const DeleteProject: React.FC<DeleteTaskProps> = ({ project_id }) => {
   const router = useRouter();
   const cookie = getCookie('auth');
   const auth = cookie?.toString() ?? '';
@@ -71,37 +73,49 @@ const DeleteProject: React.FC<DeleteTaskProps> = ({ project_id, isMember = false
     }
   };
 
-  // ซ่อนปุ่ม delete project เมื่อเป็น member
-  if (isMember) {
-    return null;
-  }
+  const [hasEditPermission, setHasEditPermission] = useState(false);
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
+        projectId: project_id,
+      });
+      setHasEditPermission(can('deleteProject', { projectRole, taskRole, isAdmin, isHead }));
+    };
+
+    checkPermission();
+  }, [project_id]);
 
   return (
-    <AlertDialog>
-      <AlertDialogTrigger>
-        <div className="w-fit h-fit py-1 px-2 bg-red-300 rounded-md border bg-white border-red justify-center items-center gap-2 inline-flex hover:bg-red group">
-          <Trash2 className="h-4 w-4 text-red group-hover:text-white" />
-          <div className="text-sm font-medium font-BaiJamjuree text-red group-hover:text-white">
-            Delete project
-          </div>
-        </div>
-      </AlertDialogTrigger>
-      <AlertDialogContent>
-        <AlertDialogHeader>
-          <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-          <AlertDialogDescription>
-            This action cannot be undone. This will permanently delete your account and remove your
-            data from our servers.
-          </AlertDialogDescription>
-        </AlertDialogHeader>
-        <AlertDialogFooter>
-          <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <AlertDialogAction onClick={handleDeleteTask} className="bg-red">
-            Delete
-          </AlertDialogAction>
-        </AlertDialogFooter>
-      </AlertDialogContent>
-    </AlertDialog>
+    <>
+      {hasEditPermission && (
+        <AlertDialog>
+          <AlertDialogTrigger>
+            <div className="w-fit h-fit py-1 px-2 bg-red-300 rounded-md border bg-white border-red justify-center items-center gap-2 inline-flex hover:bg-red group">
+              <Trash2 className="h-4 w-4 text-red group-hover:text-white" />
+              <div className="text-sm font-medium font-BaiJamjuree text-red group-hover:text-white">
+                Delete project
+              </div>
+            </div>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This action cannot be undone. This will permanently delete your account and remove
+                your data from our servers.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDeleteTask} className="bg-red">
+                Delete
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      )}
+    </>
   );
 };
 

--- a/src/components/elements/status-button.tsx
+++ b/src/components/elements/status-button.tsx
@@ -20,6 +20,7 @@ import type { TaskProps } from '@/app/types/types';
 import { useToast } from '@/hooks/use-toast';
 import { jwtDecode } from 'jwt-decode';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 const statuses: Status[] = statusSections;
 
@@ -158,27 +159,18 @@ export function StatusButton({ task }: { task: TaskProps }) {
 
   const { toast } = useToast();
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editStatus', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild className=" border-brown text-brown">

--- a/src/components/elements/subtask.tsx
+++ b/src/components/elements/subtask.tsx
@@ -9,6 +9,7 @@ import { Sort, Task } from './taskManagement';
 import type { TaskProps } from '@/app/types/types';
 import { CreateSubtask } from './createSubtask';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 // Helper functions for localStorage
 const loadExpandedState = (): Set<string> => {
@@ -38,25 +39,21 @@ const Subtask = ({ task }: { task: TaskProps }) => {
     setExpandedIds(new Set(newIds));
   };
 
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+  useEffect(() => {
+    saveExpandedState(expandedIds);
+  }, [expandedIds]);
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
-      // console.log('User role:', role, 'Is Admin:', isAdmin);
+      setHasEditPermission(can('createSubtask', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role || ''));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-
-  useEffect(() => {
-    saveExpandedState(expandedIds);
-    checkPermissions();
-  }, [expandedIds, task.projectId, task.id]);
+    checkPermission();
+  }, [task.projectId, task.id]);
 
   useEffect(() => {
     try {

--- a/src/components/elements/taskManagement/taskActionsMenu.tsx
+++ b/src/components/elements/taskManagement/taskActionsMenu.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { toast } from '@/hooks/use-toast';
 import BASE_URL from '@/lib/shared';
+import { can } from '@/permissions/helper';
 import { fetchData } from '@/service/fetchService';
 import { getUserRoleOnProjectTask } from '@/service/userService';
 import { Ellipsis } from 'lucide-react';
@@ -81,27 +82,17 @@ export const TaskActionsMenu = ({ task }: { task: TaskProps }) => {
     );
   };
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('deleteTask', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-
-  useEffect(() => {
-    checkPermissions();
+    checkPermission();
   }, [task.projectId, task.id]);
   return (
     <div className="relative">

--- a/src/components/elements/uploadfile.tsx
+++ b/src/components/elements/uploadfile.tsx
@@ -18,6 +18,7 @@ import { getCookie } from 'cookies-next';
 import type { TaskProps } from '@/app/types/types';
 import { toast } from '@/hooks/use-toast';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 
 interface Files {
   id: string;
@@ -104,27 +105,18 @@ const Uploadfile = ({ task }: { task: TaskProps }) => {
   };
 
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('uploadFile', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
   return <div>{hasEditPermission ? <FileUploader handleFile={handleFile} /> : undefined}</div>;
 };
 

--- a/src/components/elements/workspace.tsx
+++ b/src/components/elements/workspace.tsx
@@ -7,6 +7,7 @@ import Blocknotes from './blocknote';
 import { toast } from '@/hooks/use-toast';
 import type { TaskProps } from '@/app/types/types';
 import { getUserRoleOnProjectTask } from '@/service/userService';
+import { can } from '@/permissions/helper';
 interface Files {
   id: string;
   fileName: string;
@@ -158,27 +159,18 @@ const Workspace = ({ task }: { task: TaskProps }) => {
     }
   }, [textAreaRef, Title]);
   const [hasEditPermission, setHasEditPermission] = useState(false);
-  const checkPermissions = async () => {
-    try {
-      const { role, isAdmin } = await getUserRoleOnProjectTask({
+
+  useEffect(() => {
+    const checkPermission = async () => {
+      const { projectRole, taskRole, isAdmin, isHead } = await getUserRoleOnProjectTask({
         projectId: task.projectId,
         taskId: task.id,
       });
+      setHasEditPermission(can('editTitle', { projectRole, taskRole, isAdmin, isHead }));
+    };
 
-      if (!role) {
-        setHasEditPermission(false);
-        return;
-      }
-
-      setHasEditPermission(isAdmin || ['ProjectOwner', 'owner', 'assignee'].includes(role));
-    } catch (error) {
-      console.error('Failed to check permissions:', error);
-      setHasEditPermission(false);
-    }
-  };
-  useEffect(() => {
-    checkPermissions();
-  }, [task]);
+    checkPermission();
+  }, [task.projectId, task.id]);
   return (
     <div className="relative w-full">
       <label

--- a/src/permissions/helper.ts
+++ b/src/permissions/helper.ts
@@ -1,0 +1,13 @@
+import type { PermissionContext } from '@/app/types/types';
+import { taskPermission } from './taskPermission';
+import { projectPermission } from './projectPermission';
+
+type AllPermissions = typeof taskPermission & typeof projectPermission;
+
+export function can<T extends keyof AllPermissions>(
+  action: T,
+  ctx: PermissionContext,
+): ReturnType<AllPermissions[T]> {
+  const allPermissions = { ...taskPermission, ...projectPermission };
+  return allPermissions[action](ctx) as ReturnType<AllPermissions[T]>;
+}

--- a/src/permissions/projectPermission.ts
+++ b/src/permissions/projectPermission.ts
@@ -1,0 +1,76 @@
+import type { PermissionContext } from '@/app/types/types';
+
+type PermissionKey =
+  | 'editProjectTitle'
+  | 'editProjectDescription'
+  | 'editProjectOwner'
+  | 'editProjectMember'
+  | 'editProjectTag'
+  | 'editProjectDate'
+  | 'deleteProject';
+
+// Helper function สำหรับตรวจสอบสิทธิ์แบบ centralized
+const checkPermission = (ctx: PermissionContext, customLogic: () => boolean): boolean => {
+  // Admin และ Head มีสิทธิ์ทุกอย่าง
+  if (ctx.isAdmin || ctx.isHead) return true;
+  return customLogic();
+};
+
+export const projectPermission: Record<PermissionKey, (ctx: PermissionContext) => true | false> = {
+  editProjectTitle: (
+    ctx, //disable
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+  editProjectDescription: (
+    ctx, //disable
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+  editProjectOwner: (
+    ctx, //disable
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+  editProjectMember: (
+    ctx, //disable
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+  editProjectTag: (
+    ctx, //hide
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+  editProjectDate: (
+    ctx, //disable
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+  deleteProject: (
+    ctx, //hide
+  ) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.projectRole === 'Member') return false;
+      return false;
+    }),
+};

--- a/src/permissions/taskPermission.ts
+++ b/src/permissions/taskPermission.ts
@@ -1,0 +1,133 @@
+import type { PermissionContext } from '@/app/types/types';
+
+type PermissionKey =
+  | 'deleteTask'
+  | 'uploadFile'
+  | 'deleteFile'
+  | 'comment'
+  | 'editTitle'
+  | 'editDescription'
+  | 'editStatus'
+  | 'editMember'
+  | 'editTag'
+  | 'editMoney'
+  | 'editDate'
+  | 'deleteTag'
+  | 'editEmoji'
+  | 'createSubtask'
+  | 'duplicateTask';
+
+// Helper function สำหรับตรวจสอบสิทธิ์แบบ centralized
+const checkPermission = (ctx: PermissionContext, customLogic: () => boolean): boolean => {
+  // Admin และ Head มีสิทธิ์ทุกอย่าง
+  if (ctx.isAdmin || ctx.isHead) return true;
+  return customLogic();
+};
+
+export const taskPermission: Record<PermissionKey, (ctx: PermissionContext) => true | false> = {
+  editTitle: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return false;
+    }),
+  editDescription: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return false;
+    }),
+  editEmoji: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return true;
+    }),
+  uploadFile: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return false;
+    }),
+  deleteFile: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return false;
+    }),
+  comment: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return true;
+    }),
+  editStatus: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return false;
+    }),
+  editMember: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return false;
+      return false;
+    }),
+  editTag: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return false;
+      return false;
+    }),
+  deleteTag: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return false;
+      return false;
+    }),
+  editMoney: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return false;
+      return false;
+    }),
+  editDate: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return false;
+      return false;
+    }),
+  deleteTask: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return false;
+      return false;
+    }),
+  createSubtask: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return false;
+    }),
+  duplicateTask: (ctx) =>
+    checkPermission(ctx, () => {
+      if (ctx.projectRole === 'ProjectOwner') return true;
+      if (ctx.taskRole === 'owner') return true;
+      if (ctx.taskRole === 'assignee') return true;
+      return true;
+    }),
+};


### PR DESCRIPTION
# Pull Request Template

## Description

แก้ code เกี่ยวกับเรื่อง permission

check permission สามารถ classified ได้ 2 แบบสำหรับแต่ละ component คือ true(can ...), false(can't ...)

> Ex. can('createSubtask', { projectRole, taskRole, isAdmin, isHead })=>boolean

- folder permissions ไว้เก็บ permissions rule of each component in task, project
- add helper file for check permissions

## Changes Made

- เปลี่ยนวิธี call checker
- เพิ่ม permission rule ซึ่งอิงมาจาก https://docs.google.com/spreadsheets/d/1tdhqXxqBO9On4-TAmkWghkcfQktfb2rh8uo3pNx0_88/edit?gid=1567314296#gid=1567314296

## How to Test

1. Log in with user role projectRole = member, taskRole = undefined, admin = head = false
2. check each comp in page task, project details
3. Log in with another role, check again in (2)

## Checklist

- [x] ผักกี้เช็ค file permission 
- [x] ผักกี้เช็คหน้า task with role "false"
- [x] ผักกี้เช็คหน้า task with role "true"
- [x] ผักกี้เช็คหน้า project detail with role "false"
- [x] ผักกี้เช็คหน้า project detail with role "true"

## Additional Notes

อยากให้ผักเช็คก่อน